### PR TITLE
Add behaviorHints and idPrefixes to manifest for Nuvio compat

### DIFF
--- a/index.js
+++ b/index.js
@@ -345,7 +345,9 @@ const builder = new addonBuilder({
   name: FILTER_ENABLED ?"Ultra MAX" :"Ultra MAX All",
   description:"Dev build v5.3",
   types: ["movie","series"],
+  idPrefixes: ["tt", "tmdb"],
   resources: ["catalog","meta","stream"],
+  behaviorHints: { configurable: true, configurationRequired: false, adult: false, p2p: false },
   catalogs: [
     { type:"movie",  id:"ultramax_placeholder", name:"Ultra MAX", extra: [{ name:"skip", isRequired: false }] }
   ]
@@ -783,7 +785,9 @@ app.get("/c/:token/manifest.json", (req, res) => {
     description: `Custom addon with ${config.catalogs.length} catalogs`,
     logo: "https://max-streams.gleeze.com/logo.svg",
     types: ["movie","series"],
+    idPrefixes: ["tt", "tmdb"],
     resources: ["catalog","meta","stream"],
+    behaviorHints: { configurable: true, configurationRequired: false, adult: false, p2p: false },
     catalogs: [
       ...buildCatalogsFromIds(config.catalogs),
       { type:"movie", id:"search_movies", name:"Ultra MAX", extra:[{ name:"search", isRequired:true }] },
@@ -868,7 +872,9 @@ app.use((req, res, next) => {
       name: FILTER_ENABLED ?"Ultra MAX" :"Ultra MAX All",
       description: FILTER_ENABLED ?"Filtered content" :"All content",
       types: ["movie","series"],
+      idPrefixes: ["tt", "tmdb"],
       resources: ["catalog","meta","stream"],
+      behaviorHints: { configurable: true, configurationRequired: false, adult: false, p2p: false },
       catalogs: [
         ...buildManifestCatalogs(staticIds),
         ...DYNAMIC_CATALOGS.map(c => ({ type: c.type, id: c.id, name: c.name, extra: [{ name:"tmdbId", isRequired: true }] })),


### PR DESCRIPTION
Fixes #14.

## What

Adds `idPrefixes: ["tt", "tmdb"]` and `behaviorHints: { configurable: true, configurationRequired: false, adult: false, p2p: false }` to all three manifest construction sites:

- `addonBuilder` instantiation (default/unconfigured manifest, ~L340)
- `/c/:token/manifest.json` route (custom-config manifest, ~L780)
- The global `/manifest.json` middleware path (~L865)

## Why

Stremio forks — most notably **Nuvio** ([tapframe/NuvioStreaming](https://github.com/tapframe/NuvioStreaming), Kotlin Multiplatform) — treat `behaviorHints` and `idPrefixes` as effectively required despite the SDK schema marking them optional. Without them, install on Nuvio fails with:

> Element class of x is not a JsonObject

(That string is from `kotlinx.serialization`'s `JsonElement.jsonObject` getter throwing on a non-object.) Full diagnosis in #14.

The reference Nuvio-compatible addon (`tapframe/NuvioStreamsAddon`) ships these fields. Official Stremio clients ignore them when present, so this is a no-op for them and a fix for Nuvio.

## Diff

3 lines × 3 sites = 6 lines added, 0 removed. No behavior change for existing Stremio clients.

## Testing

- `node --check index.js` passes
- Manifest at all three endpoints continues to be valid JSON with the new fields

## Not addressed in this PR

The 216-catalog count and `/configure` URL-normalization edge case from #14 are still open — happy to follow up on those in separate PRs if you want to tackle them.